### PR TITLE
Add Substack writing feed

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,17 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "substackcdn.com",
+      },
+      {
+        protocol: "https",
+        hostname: "substack-post-media.s3.amazonaws.com",
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "next": "14.2.4",
         "next-mdx-remote": "^6.0.0",
         "react": "^18",
-        "react-dom": "^18"
+        "react-dom": "^18",
+        "rss-parser": "^3.13.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -1712,6 +1713,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -5808,6 +5818,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rss-parser": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
+      "integrity": "sha512-7jWUBV5yGN3rqMMj7CZufl/291QAhvrrGpDNE4k/02ZchL0npisiYYqULF71jCEKoIiHvK/Q2e6IkDwPziT7+w==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^2.0.3",
+        "xml2js": "^0.5.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5867,6 +5887,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
       }
     },
     "node_modules/scheduler": {
@@ -7061,6 +7090,28 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/yaml": {
       "version": "2.4.5",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next": "14.2.4",
     "next-mdx-remote": "^6.0.0",
     "react": "^18",
-    "react-dom": "^18"
+    "react-dom": "^18",
+    "rss-parser": "^3.13.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/components/Nav.tsx
+++ b/src/app/components/Nav.tsx
@@ -14,7 +14,7 @@ export default function Nav() {
   const pathname = usePathname();
 
   return (
-    <nav className="flex gap-6 px-10 py-6 font-dm-mono text-sm">
+    <nav className="flex justify-center gap-6 px-10 py-6 font-dm-mono text-sm">
       {links.map(({ href, label }) =>
         href === pathname ? (
           <span

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -6,7 +6,7 @@ export default function Recipes() {
   const recipes = getRecipes();
 
   return (
-    <main className="px-10 py-16 max-w-4xl">
+    <main className="px-10 py-16 max-w-4xl mx-auto">
       <h2 className="text-3xl font-bold mb-2">recipes</h2>
       <p className="text-lg opacity-75 mb-10">
         Life is busy, but you deserve good food.

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -7,7 +7,7 @@ const links = [
 
 export default function Work() {
   return (
-    <main className="px-10 py-16 max-w-2xl">
+    <main className="px-10 py-16 max-w-4xl mx-auto">
       <h2 className="text-3xl font-bold mb-10">work</h2>
 
       <section className="mb-10">

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -1,8 +1,70 @@
-export default function Writing() {
+import Link from "next/link";
+import Image from "next/image";
+import { getPosts } from "@/lib/writing";
+
+export const revalidate = 3600; // refresh feed every hour
+
+// Uncomment to add RSS autodiscovery — lets RSS readers detect the feed automatically.
+// Also uncomment the subscribe link below.
+// export const metadata = {
+//   alternates: {
+//     types: {
+//       "application/rss+xml": "https://tammyislearning.substack.com/feed",
+//     },
+//   },
+// };
+
+export default async function Writing() {
+  const posts = await getPosts();
+
   return (
-    <main className="flex flex-col items-center px-10 py-16">
-      <h2 className="text-2xl font-mono mb-4">writing</h2>
-      <p className="text-sm opacity-50">coming soon</p>
+    <main className="px-10 py-16 max-w-4xl mx-auto">
+      <h2 className="text-3xl font-bold mb-2">writing</h2>
+      <p className="text-lg opacity-75 mb-10">
+        Tammy is learning. Endlessly.
+      </p>
+      {/* Subscribe link — uncomment when ready to make the feed discoverable.
+      <Link
+        href="https://tammyislearning.substack.com/feed"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-xs font-dm-mono opacity-50 hover:text-yellow-gold hover:opacity-100 transition-colors duration-200"
+      >
+        subscribe via RSS ↗
+      </Link>
+      */}
+      <ul className="flex flex-col gap-3">
+        {posts.map((post) => (
+          <li key={post.link}>
+            <Link
+              href={post.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex gap-4 items-start border border-white/10 hover:border-yellow-gold/40 rounded-xl px-4 py-4 transition-colors duration-200"
+            >
+              <div className="flex flex-col gap-1 flex-1">
+                <span className="font-semibold group-hover:text-yellow-gold transition-colors duration-200">
+                  {post.title}
+                </span>
+                <span className="text-xs opacity-50 font-dm-mono">{post.date}</span>
+                {post.excerpt && (
+                  <span className="text-sm opacity-70 mt-1">{post.excerpt}</span>
+                )}
+              </div>
+              {post.image && (
+                <div className="relative w-28 h-20 shrink-0 rounded-lg overflow-hidden">
+                  <Image
+                    src={post.image}
+                    alt={post.title}
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+              )}
+            </Link>
+          </li>
+        ))}
+      </ul>
     </main>
   );
 }

--- a/src/lib/writing.ts
+++ b/src/lib/writing.ts
@@ -1,0 +1,33 @@
+import Parser from "rss-parser";
+
+const FEED_URL = "https://tammyislearning.substack.com/feed";
+
+export type Post = {
+  title: string;
+  link: string;
+  date: string;
+  excerpt: string;
+  image?: string;
+};
+
+export async function getPosts(): Promise<Post[]> {
+  const parser = new Parser({
+    customFields: { item: [["enclosure", "enclosure", { keepArray: false }]] },
+  });
+
+  const feed = await parser.parseURL(FEED_URL);
+
+  return feed.items.map((item) => ({
+    title: item.title ?? "",
+    link: item.link ?? "",
+    date: item.pubDate
+      ? new Date(item.pubDate).toLocaleDateString("en-US", {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        })
+      : "",
+    excerpt: item.contentSnippet?.split("\n")[0] ?? "",
+    image: (item as any).enclosure?.url,
+  }));
+}


### PR DESCRIPTION
## Summary

- Pulls posts from `tammyislearning.substack.com/feed` via `rss-parser` and displays them on `/writing` with title, date, excerpt, and cover image thumbnail
- Post cards link out to Substack, revalidate every hour
- Commented-out RSS autodiscovery metadata + subscribe link ready to uncomment when needed
- Substack CDN domains added to `next.config.mjs` for `next/image`
- Nav centered, all inner pages use `max-w-4xl mx-auto` for consistent heading position across pages

## Test plan

- [x] `/writing` loads and shows posts from Substack
- [x] Each post card shows title, date, excerpt, and thumbnail where available
- [x] Clicking a card opens the correct Substack post in a new tab
- [x] Nav is centered on all pages
- [x] Heading position is consistent across `/work`, `/writing`, `/recipes`

🤖 Generated with [Claude Code](https://claude.com/claude-code)