### PR TITLE
Recipe styling and recommendations section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+const figureSkatingUrl = "https://www.instagram.com/tamz.on.ice";
+
 function CustomLink({
   href,
   className = "",
@@ -20,25 +22,23 @@ function CustomLink({
 }
 
 function Title() {
-  const goalsUrl = "https://asana.com/features/goals-reporting/goals";
-
   return (
     <h1 className="flex font-bold text-graphite-heading">
-      <p><span className="text-yellow-gold">Tammy</span> is building software by daylight ☀️</p>
-    </h1>
-  );
-}
-
-function SubTitle() {
-  const figureSkatingUrl = "https://www.instagram.com/tamz.on.ice";
-  return (
-    <h4 className="flex text-graphite-heading">
       <p>
+        <span className="text-yellow-gold">Tammy</span> is{" "}
         <CustomLink className="underline" href={figureSkatingUrl}>
           figure skater
         </CustomLink>{" "}
         by moonlight &#127769;
       </p>
+    </h1>
+  );
+}
+
+function SubTitle() {
+  return (
+    <h4 className="flex text-graphite-heading">
+      <p> software engineer by daylight ☀️ </p>
     </h4>
   );
 }

--- a/src/app/recipes/[slug]/page.tsx
+++ b/src/app/recipes/[slug]/page.tsx
@@ -1,5 +1,5 @@
 import { MDXRemote } from "next-mdx-remote/rsc";
-import { getRecipe, getRecipes } from "@/lib/recipes";
+import { getRecipe, getRecipes, formatDate } from "@/lib/recipes";
 
 const components = {
   h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
@@ -23,6 +23,9 @@ const components = {
   li: (props: React.HTMLAttributes<HTMLLIElement>) => (
     <li className="pl-1" {...props} />
   ),
+  strong: (props: React.HTMLAttributes<HTMLElement>) => (
+    <strong className="text-yellow-gold" {...props} />
+  ),
 };
 
 export async function generateStaticParams() {
@@ -37,12 +40,15 @@ export default function RecipePage({
   const { meta, content } = getRecipe(params.slug);
 
   return (
-    <main className="px-10 py-16 max-w-2xl">
-      <h1 className="text-3xl font-bold mb-1">{meta.title}</h1>
-      <p className="text-sm opacity-50 mb-10">{meta.duration}</p>
+    <main className="px-10 py-16 max-w-4xl mx-auto">
+      <h1 className="text-3xl font-bold mb-2">{meta.title}</h1>
+      <p className="text-sm opacity-100 font-dm-mono mb-10">
+        {meta.duration} · {meta.serving}
+      </p>
       <article className="flex flex-col gap-4 leading-relaxed">
         <MDXRemote source={content} components={components} />
       </article>
+
     </main>
   );
 }

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import Image from "next/image";
-import { getRecipes } from "@/lib/recipes";
+import { getRecipes, formatDate } from "@/lib/recipes";
 
 export default function Recipes() {
   const recipes = getRecipes();
@@ -8,8 +8,12 @@ export default function Recipes() {
   return (
     <main className="px-10 py-16 max-w-4xl mx-auto">
       <h2 className="text-3xl font-bold mb-2">recipes</h2>
-      <p className="text-lg opacity-75 mb-10">
-        Life is busy, but you deserve good food.
+      <p className="text-lg opacity-75 mb-4"></p>
+
+      <p className="text-sm mb-10">
+        <b>Life is busy, but you deserve good food.</b> Daily cooking is an
+        endurance sport in itself, and you need something easy, mindless, and
+        still tasty. These are my weekly staples.
       </p>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {recipes.map((recipe) => (
@@ -29,12 +33,63 @@ export default function Recipes() {
               <div className="w-full h-full bg-gradient-to-br from-white/10 to-white/5" />
             )}
             <div className="absolute bottom-0 inset-x-0 px-4 py-3 bg-black/40 backdrop-blur-sm">
-              <span className="text-sm font-medium text-graphite-heading">{recipe.title}</span>
-              <span className="text-xs opacity-60 ml-2">{recipe.duration}</span>
+              <span className="text-sm font-medium text-graphite-heading block">
+                {recipe.title}
+              </span>
+              <span className="text-xs opacity-60 font-dm-mono">
+                {recipe.duration}
+              </span>
             </div>
           </Link>
         ))}
       </div>
+
+      <section className="mt-12">
+        <h2 className="text-3xl font-semibold mb-4">recommendations</h2>
+        <h3 className="text-lg font-semibold mb-2">cookware</h3>
+        <ul className="list-disc list-outside pl-5 flex flex-col gap-1 text-sm opacity-80">
+          <li>
+            <strong className="text-graphite-heading font-bold">
+              Chef&apos;s knife.
+            </strong>{" "}
+            This is going to be sufficient for most chopping/slicing needs. If
+            you invest in one thing, invest in this.
+          </li>
+          <li>
+            <strong className="text-graphite-heading font-bold">
+              Baking sheet & parchment paper.
+            </strong>{" "}
+            For all your roasting/baking needs. A quarter is sufficient for most
+            recipes, but if you use the oven often then get a half.
+          </li>
+        </ul>
+        <h3 className="text-lg font-semibold mb-2 mt-2">spices</h3>
+        <ul className="list-disc list-outside pl-5 flex flex-col gap-1 text-sm opacity-80">
+          <li>
+            <strong className="text-graphite-heading font-bold">
+              Garlic powder.
+            </strong>{" "}
+            Great with most vegetables.
+          </li>
+          <li>
+            <strong className="text-graphite-heading font-bold">
+              Chili powder.
+            </strong>{" "}
+            Easy way to spice up protein.
+          </li>
+          <li>
+            <strong className="text-graphite-heading font-bold">Honey.</strong>{" "}
+            Richer than simple sugar and more versatile so you can have it with
+            an evening tea.
+          </li>
+          <li>
+            <strong className="text-graphite-heading font-bold">
+              Dijon mustard.
+            </strong>{" "}
+            Great for marinades and sauces.
+          </li>
+        </ul>
+      </section>
     </main>
   );
 }

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -8,17 +8,23 @@ const links = [
 export default function Work() {
   return (
     <main className="px-10 py-16 max-w-4xl mx-auto">
-      <h2 className="text-3xl font-bold mb-10">work</h2>
-
+      <h2 className="text-3xl font-bold mb-4">work</h2>
+      <p className="text-sm mb-10">
+        My daily 9-5, or 11-7. Or...who even knows.
+      </p>
       <section className="mb-10">
-        <h3 className="text-xs uppercase tracking-widest opacity-90 mb-4">resume</h3>
+        <h3 className="text-xs uppercase tracking-widest opacity-90 mb-4">
+          resume
+        </h3>
         <div className="border border-white/10 rounded-xl px-6 py-5 text-sm opacity-90">
           coming soon
         </div>
       </section>
 
       <section>
-        <h3 className="text-xs uppercase tracking-widest opacity-90 mb-4">links</h3>
+        <h3 className="text-xs uppercase tracking-widest opacity-90 mb-4">
+          links
+        </h3>
         <ul className="flex flex-col gap-3">
           {links.map(({ label, href }) => (
             <li key={href}>

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -19,9 +19,9 @@ export default async function Writing() {
 
   return (
     <main className="px-10 py-16 max-w-4xl mx-auto">
-      <h2 className="text-3xl font-bold mb-2">writing</h2>
-      <p className="text-lg opacity-75 mb-10">
-        Tammy is learning. Endlessly.
+      <h2 className="text-3xl font-bold mb-4">writing</h2>
+      <p className="text-sm mb-10">
+        TIL. My blog of thoughts and of aspirationally whimsy.
       </p>
       {/* Subscribe link — uncomment when ready to make the feed discoverable.
       <Link
@@ -46,9 +46,13 @@ export default async function Writing() {
                 <span className="font-semibold group-hover:text-yellow-gold transition-colors duration-200">
                   {post.title}
                 </span>
-                <span className="text-xs opacity-50 font-dm-mono">{post.date}</span>
+                <span className="text-xs opacity-50 font-dm-mono">
+                  {post.date}
+                </span>
                 {post.excerpt && (
-                  <span className="text-sm opacity-70 mt-1">{post.excerpt}</span>
+                  <span className="text-sm opacity-70 mt-1">
+                    {post.excerpt}
+                  </span>
                 )}
               </div>
               {post.image && (

--- a/src/content/recipes/honey-mustard-chicken.mdx
+++ b/src/content/recipes/honey-mustard-chicken.mdx
@@ -1,0 +1,31 @@
+---
+title: Honey mustard chicken & salad
+duration: 30 mins
+serving: 1 person
+date: 2026-05-23
+---
+
+Chicken breast doesn't need to be boring, but it does need to be easy. Mustard and a bit of honey does wonders to the flavour for this staple protein. You can substitute the salad with air fried veggies but I find chicken can be quite hearty. For a heartier salad, you can use Kewpie sesame dressing which will still cut through the chicken fat but still be full bodied.
+
+# Ingredients
+
+- 1 chicken breast / thigh
+- 1 serving of salad vegetables (eg. spinach, spring mix)
+
+## Spices
+
+- 1 tbsp dijon mustard
+- 1 tbsp honey
+- 1 tbsp chili flakes in oil (eg. Lao gan ma or similar)
+- Salt, pepper
+- Balsamic vinegar or Kewpie Sesame dressing
+
+# Steps
+
+1. Heat oven to 425°F. Line a sheet pan with parchment.
+1. Use the back of your knife to tenderize the **chicken** breast by "chopping" it repeatedly with the dull back of the knife. If you have an especially big piece, I'd score the surface so that it's easier to season and cook.
+1. Make the seasoning in a bowl with a spoon of mustard, honey, and chili flake oil and stir it together.
+1. Season the chicken with salt and rub it in. Then rub the seasoning mix over the top and bottom.
+1. Put the chicken in the oven (if thighs, skin up) for 20 minutes until 160°F (or 175°F for thigh).
+1. Toss **salad** with olive oil, salt, and balsamic vinegar. Or just use the sesame dressing on its own with a bit of sale.
+1. Plate together and serve.

--- a/src/content/recipes/salmon-and-vegetables.mdx
+++ b/src/content/recipes/salmon-and-vegetables.mdx
@@ -24,9 +24,9 @@ This recipe doesn't include any carbs, so add a side of rice or bread as you'd p
 # Steps
 
 1. Heat oven to 425°F. Line a sheet pan with parchment.
-1. Descale your salmon. If you're cooking for several, slice it to about a palm's size for each person.
+1. Descale your **salmon**. If you're cooking for several, slice it to about a palm's size for each person.
 1. Rub the salmon with salt, pepper, and chili powder. Make sure to really use your hands to massage the salmon, it'll keep it tender after cooking while introducing flavour.
 1. Put the salmon in the oven for 12 minutes, skin up.
-1. Toss vegetables in 1 tbsp olive oil, salt, and garlic powder.
+1. Toss **vegetables** in 1 tbsp olive oil, salt, and garlic powder.
 1. Air fry the vegetables for about 8 minutes at 325°F. Then toss them to continue frying for another 4 minutes to make sure it's evenly crispy.
 1. Plate them together and serve.

--- a/src/lib/recipes.ts
+++ b/src/lib/recipes.ts
@@ -8,9 +8,19 @@ export type RecipeMeta = {
   slug: string;
   title: string;
   duration: string;
+  serving: string;
   date: string;
   image?: string; // path relative to /public, e.g. /recipes/salmon.jpg
 };
+
+export function formatDate(date: string): string {
+  return new Date(date).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
 
 export function getRecipes(): RecipeMeta[] {
   const files = fs.readdirSync(recipesDir).filter((f) => f.endsWith(".mdx"));


### PR DESCRIPTION
## Summary

- Serving size added to `RecipeMeta` and shown on the recipe detail page alongside duration
- Recipe detail metadata row bumped to full opacity in DM Mono
- Bold text in MDX recipes renders yellow-gold; all inner pages use `max-w-4xl mx-auto` for consistent centering
- Recommendations section (cookware & spices) added to bottom of `/recipes` index with bolded white labels
- Home page copy updated

## Test plan

- [x] `/recipes` shows card grid with duration in overlay and recommendations section below
- [x] `/recipes/[slug]` shows `duration · serving` metadata below title
- [x] Bold text in MDX renders yellow-gold
- [x] All pages (work, writing, recipes, recipe detail) have consistent left-edge alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)