### PR TITLE
Responsive recipe pages: mobile single-column layout

### DIFF
--- a/src/app/recipes/[slug]/page.tsx
+++ b/src/app/recipes/[slug]/page.tsx
@@ -2,6 +2,8 @@ import Image from "next/image";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import { getRecipe, getRecipes } from "@/lib/recipes";
 
+export const dynamicParams = false;
+
 const components = {
   h1: (props: React.HTMLAttributes<HTMLHeadingElement>) => (
     <h1 className="text-2xl font-bold mt-4" {...props} />
@@ -33,35 +35,70 @@ export async function generateStaticParams() {
   return getRecipes().map((r) => ({ slug: r.slug }));
 }
 
-export default function RecipePage({
+export default async function RecipePage({
   params,
 }: {
-  params: { slug: string };
+  params: Promise<{ slug: string }>;
 }) {
-  const { meta, content } = getRecipe(params.slug);
+  const { slug } = await params;
+  const { meta, content } = getRecipe(slug);
+
+  // Split intro (before first heading) from the rest of the content
+  const firstHeadingIndex = content.search(/^#/m);
+  const intro =
+    firstHeadingIndex > 0 ? content.slice(0, firstHeadingIndex).trim() : "";
+  const body =
+    firstHeadingIndex > 0 ? content.slice(firstHeadingIndex).trim() : content;
 
   return (
-    <main className="px-10 py-16 max-w-5xl mx-auto">
-      <div className="flex gap-10 items-start">
+    <main className="px-6 py-16 max-w-5xl mx-auto">
+      {/* Mobile: single column. Desktop: two columns */}
+      <div className="flex flex-col md:flex-row md:gap-10 md:items-start">
+        {/* Left column on desktop: image */}
         {meta.image && (
-          <div className="relative w-80 shrink-0 rounded-xl overflow-hidden">
+          <div className="hidden md:block md:relative md:w-96 md:shrink-0 rounded-xl overflow-hidden">
             <Image
               src={meta.image}
               alt={meta.title}
-              width={320}
+              width={384}
               height={0}
               style={{ height: "auto" }}
               className="w-full"
             />
           </div>
         )}
+
+        {/* Right column on desktop, full column on mobile */}
         <div className="flex-1 min-w-0">
           <h1 className="text-3xl font-bold mb-2">{meta.title}</h1>
-          <p className="text-sm opacity-60 font-dm-mono mb-8">
+          <p className="text-sm opacity-60 font-dm-mono mb-6">
             {meta.duration} · {meta.serving}
           </p>
+
+          {/* Intro paragraph */}
+          {intro && (
+            <article className="flex flex-col gap-4 leading-relaxed mb-4">
+              <MDXRemote source={intro} components={components} />
+            </article>
+          )}
+
+          {/* Image appears here on mobile, between intro and ingredients */}
+          {meta.image && (
+            <div className="block md:hidden relative rounded-xl overflow-hidden mb-6">
+              <Image
+                src={meta.image}
+                alt={meta.title}
+                width={800}
+                height={0}
+                style={{ height: "auto" }}
+                className="w-full"
+              />
+            </div>
+          )}
+
+          {/* Ingredients, steps, etc. */}
           <article className="flex flex-col gap-4 leading-relaxed">
-            <MDXRemote source={content} components={components} />
+            <MDXRemote source={body} components={components} />
           </article>
         </div>
       </div>

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -10,9 +10,7 @@ export default function Work() {
     <main className="px-10 py-16 max-w-4xl mx-auto">
       <h2 className="text-3xl font-bold mb-4">work</h2>
       <p className="mb-10">
-        <b>My daily 9-5, or 11-7, or whatever needs be.</b>
-        I&apos;m traditionally a full stack product engineer, right now I work on AI
-        retrieval.
+        Full stack product engineer, currently working on AI retrieval.
       </p>
 
       <section>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compilerOptions": {
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -10,7 +14,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -18,9 +22,20 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
-    }
+      "@/*": [
+        "./src/*"
+      ]
+    },
+    "target": "ES2017"
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

- **Mobile**: single-column layout — title → intro text → image (full width) → ingredients/steps
- **Desktop** (`md+`): two-column layout with a larger image (384px, up from 320px) on the left and all content on the right
- Fixes a pre-existing build failure: Next.js 16 requires `params` to be awaited as a `Promise` in App Router pages
- Minor copy edit on the work page

## Notes for reviewer

The content split (intro vs. ingredients/steps) is done by slicing the MDX string at the first `#` heading, so the image slot on mobile always lands between the description and the structured content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)