### PR TITLE
Orange accent theme with reusable orange/blue palettes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# local preview tooling
+.claude/
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/src/app/components/AccentToggle.tsx
+++ b/src/app/components/AccentToggle.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+function subscribe(callback: () => void) {
+  const observer = new MutationObserver(callback);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["data-accent"],
+  });
+  return () => observer.disconnect();
+}
+
+function getSnapshot() {
+  return document.documentElement.getAttribute("data-accent") === "blue"
+    ? "blue"
+    : "orange";
+}
+
+export default function AccentToggle() {
+  const accent = useSyncExternalStore(subscribe, getSnapshot, () => "orange");
+  const isBlue = accent === "blue";
+
+  function toggle() {
+    const next = isBlue ? "orange" : "blue";
+    if (next === "blue") {
+      document.documentElement.setAttribute("data-accent", "blue");
+    } else {
+      document.documentElement.removeAttribute("data-accent");
+    }
+    localStorage.setItem("accent", next);
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={`Switch accent to ${isBlue ? "orange" : "blue"}`}
+      title={`Switch accent to ${isBlue ? "orange" : "blue"}`}
+      className="fixed top-4 right-14 opacity-60 hover:opacity-100 transition-opacity text-base leading-none"
+    >
+      <span style={{ color: isBlue ? "#E8924F" : "#5C7AB4" }}>◉</span>
+    </button>
+  );
+}

--- a/src/app/components/Nav.tsx
+++ b/src/app/components/Nav.tsx
@@ -19,7 +19,7 @@ export default function Nav() {
         href === pathname ? (
           <span
             key={href}
-            className="underline decoration-yellow-gold decoration-2 underline-offset-4"
+            className="underline decoration-accent decoration-2 underline-offset-4"
           >
             {label}
           </span>
@@ -27,7 +27,7 @@ export default function Nav() {
           <Link
             key={href}
             href={href}
-            className="hover:text-yellow-gold transition-colors ease-in-out duration-200"
+            className="hover:text-accent transition-colors ease-in-out duration-200"
           >
             {label}
           </Link>

--- a/src/app/components/ThemeToggle.tsx
+++ b/src/app/components/ThemeToggle.tsx
@@ -20,8 +20,24 @@ export default function ThemeToggle() {
 
   function toggle() {
     const next = !dark;
+
+    // Suppress all transitions during the switch so links/text don't
+    // flash by animating their color change at different speeds.
+    const style = document.createElement("style");
+    style.appendChild(
+      document.createTextNode("*{transition:none !important}")
+    );
+    document.head.appendChild(style);
+
     document.documentElement.classList.toggle("dark", next);
     localStorage.setItem("theme", next ? "dark" : "light");
+
+    // Force a reflow so the color change applies while transitions are
+    // off, then restore transitions on the next frame.
+    window.getComputedStyle(document.body).getPropertyValue("opacity");
+    requestAnimationFrame(() => {
+      document.head.removeChild(style);
+    });
   }
 
   return (

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,13 +5,30 @@
 :root {
   --foreground: 28, 25, 23;           /* #1c1917 dark text for light mode */
   --background: 250, 250, 249;        /* #fafaf9 warm white */
-  --heading: 250, 181, 45;            /* #FAB52D yellow-gold */
+
+  /* Brand palettes — kept available for reuse elsewhere in the app.
+     Orange is the active accent. Blue can be applied by setting
+     <html data-accent="blue"> (see AccentToggle, currently disabled). */
+  --orange-light: #e57e4a;            /* terracotta */
+  --orange-dark: #e8924f;             /* brightened terracotta */
+  --blue-light: #4a6ba8;              /* periwinkle */
+  --blue-dark: #7e9bd4;               /* lifted periwinkle */
+
+  --accent: var(--orange-light);
 }
 
 html.dark {
   --foreground: 214, 211, 209;        /* #d6d3d1 graphite-body */
   --background: 28, 25, 23;           /* #1c1917 graphite-bg */
-  --heading: 250, 181, 45;            /* #FAB52D yellow-gold */
+  --accent: var(--orange-dark);
+}
+
+/* Blue accent (toggle) — background stays graphite */
+html[data-accent="blue"] {
+  --accent: var(--blue-light);
+}
+html[data-accent="blue"].dark {
+  --accent: var(--blue-dark);
 }
 
 body {
@@ -20,7 +37,7 @@ body {
 }
 
 h1, h2, h3, h4, h5, h6 {
-  color: rgb(var(--heading));
+  color: var(--accent);
 }
 
 @layer utilities {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,9 @@ import { Noto_Sans, Noto_Sans_Mono, Plus_Jakarta_Sans, DM_Mono } from "next/font
 import "@/app/globals.css";
 import Nav from "@/app/components/Nav";
 import ThemeToggle from "@/app/components/ThemeToggle";
+// Blue accent toggle disabled for now — re-enable by uncommenting this
+// import and the <AccentToggle /> below.
+// import AccentToggle from "@/app/components/AccentToggle";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
@@ -44,12 +47,13 @@ export default function RootLayout({
       <head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `(function(){var t=localStorage.getItem('theme');if(t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}})()`,
+            __html: `(function(){/* blue accent disabled for now: if(localStorage.getItem('accent')==='blue'){document.documentElement.setAttribute('data-accent','blue')} */var t=localStorage.getItem('theme');if(t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}})()`,
           }}
         />
       </head>
       <body className={`${plusJakartaSans.className} ${dmMono.variable}`}>
         <ThemeToggle />
+        {/* <AccentToggle /> */}
         <Nav />
         {children}
         <footer className="fixed bottom-0 right-0 p-6 text-xs opacity-30">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ function CustomLink({
 }) {
   return (
     <Link
-      className={`underline-offset-auto	hover:text-yellow-gold hover:transition-colors ease-in-out duration-200 ${className}`}
+      className={`underline-offset-auto hover:text-accent hover:transition-colors ease-in-out duration-200 ${className}`}
       href={href}
     >
       {children}
@@ -25,7 +25,7 @@ function Title() {
   return (
     <h1 className="flex font-bold text-graphite-bg dark:text-graphite-heading">
       <p>
-        <span className="text-yellow-gold">Tammy</span> is{" "}
+        <span className="text-accent">Tammy</span> is{" "}
         <CustomLink className="underline" href={figureSkatingUrl}>
           figure skater
         </CustomLink>{" "}

--- a/src/app/recipes/[slug]/page.tsx
+++ b/src/app/recipes/[slug]/page.tsx
@@ -27,7 +27,7 @@ const components = {
     <li className="pl-1" {...props} />
   ),
   strong: (props: React.HTMLAttributes<HTMLElement>) => (
-    <strong className="text-yellow-gold" {...props} />
+    <strong className="text-accent" {...props} />
   ),
 };
 

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -20,7 +20,7 @@ export default function Recipes() {
           <Link
             key={recipe.slug}
             href={`/recipes/${recipe.slug}`}
-            className="group relative aspect-[4/3] rounded-xl overflow-hidden border border-black/10 dark:border-white/10 hover:border-yellow-gold/40 transition-colors duration-200"
+            className="group relative aspect-[4/3] rounded-xl overflow-hidden border border-black/10 dark:border-white/10 hover:border-accent/40 transition-colors duration-200"
           >
             {recipe.previewImage ?? recipe.image ? (
               <Image

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,8 +1,38 @@
 import Link from "next/link";
 
+function LinkedInIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className="h-4 w-4 shrink-0"
+    >
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 0 1-2.063-2.065 2.064 2.064 0 1 1 2.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className="h-4 w-4 shrink-0"
+    >
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.91 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222 0 1.606-.014 2.898-.014 3.293 0 .322.216.694.825.576C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
+
 const links = [
-  { label: "linkedin", href: "https://www.linkedin.com/in/tammyliutm/" },
-  { label: "github", href: "https://github.com/tammy" },
+  {
+    label: "linkedin",
+    href: "https://www.linkedin.com/in/tammyliutm/",
+    icon: <LinkedInIcon />,
+  },
+  { label: "github", href: "https://github.com/tammy", icon: <GitHubIcon /> },
 ];
 
 export default function Work() {
@@ -14,18 +44,16 @@ export default function Work() {
       </p>
 
       <section>
-        <h3 className="text-xs uppercase tracking-widest opacity-90 mb-4">
-          find me
-        </h3>
         <ul className="flex flex-col gap-3">
-          {links.map(({ label, href }) => (
+          {links.map(({ label, href, icon }) => (
             <li key={href}>
               <Link
                 href={href}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="font-mono text-sm hover:text-yellow-gold transition-colors duration-200"
+                className="flex items-center gap-2 font-mono text-sm hover:text-accent transition-colors duration-200"
               >
+                {icon}
                 {label}
               </Link>
             </li>

--- a/src/app/writing/page.tsx
+++ b/src/app/writing/page.tsx
@@ -28,7 +28,7 @@ export default async function Writing() {
         href="https://tammyislearning.substack.com/feed"
         target="_blank"
         rel="noopener noreferrer"
-        className="text-xs font-dm-mono opacity-50 hover:text-yellow-gold hover:opacity-100 transition-colors duration-200"
+        className="text-xs font-dm-mono opacity-50 hover:text-accent hover:opacity-100 transition-colors duration-200"
       >
         subscribe via RSS ↗
       </Link>
@@ -40,10 +40,10 @@ export default async function Writing() {
               href={post.link}
               target="_blank"
               rel="noopener noreferrer"
-              className="group flex gap-4 items-start border border-black/10 dark:border-white/10 hover:border-yellow-gold/40 rounded-xl px-4 py-4 transition-colors duration-200"
+              className="group flex gap-4 items-start border border-black/10 dark:border-white/10 hover:border-accent/40 rounded-xl px-4 py-4 transition-colors duration-200"
             >
               <div className="flex flex-col gap-1 flex-1">
-                <span className="font-semibold group-hover:text-yellow-gold transition-colors duration-200">
+                <span className="font-semibold group-hover:text-accent transition-colors duration-200">
                   {post.title}
                 </span>
                 <span className="text-xs opacity-50 font-dm-mono">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,12 +20,13 @@ const config: Config = {
       colors: {
         "blue-dark": "#000129",
         "blue-medium": "#0B85DA",
-        "yellow-gold": "#FAB52D",
         "graphite-bg": "#1c1917",
         "graphite-surface": "#292524",
         "graphite-heading": "#fafaf9",
         "graphite-body": "#d6d3d1",
         "graphite-muted": "#78716c",
+        // theme-aware accent (orange by default, blue via toggle)
+        accent: "var(--accent)",
       },
     },
   },


### PR DESCRIPTION
## Summary

Reworks the site accent from yellow-gold to a terracotta **orange**, while keeping the existing graphite background. The accent is driven by a single `--accent` CSS variable, so light and dark mode each get a tuned shade.

Both the orange and blue palettes are kept around (named, reusable CSS vars) so they can be used elsewhere in the app later.

## Changes

- **Orange accent**: `#e57e4a` (light) / `#e8924f` (dark), applied to "Tammy", links, nav underline, and headings via `--accent`.
- **Reusable palettes**: `--orange-light/-dark` and `--blue-light/-dark` defined in `globals.css` for future reuse.
- **Blue accent (disabled for now)**: `AccentToggle` component + `[data-accent="blue"]` rules switch the accent to blue without changing the background. Wiring in `layout.tsx` is commented out — uncomment the import + `<AccentToggle />` to re-enable.
- **No more theme-switch flash**: transitions are briefly suppressed during the dark/light flip so links don't lag behind the rest of the text.
- **Work page**: removed the "find me" heading; added LinkedIn and GitHub icons before each link (they inherit the accent color on hover).
- **Cleanup**: removed the now-unused `yellow-gold` token; added `.claude/` (local preview tooling) to `.gitignore`.

## Testing

- `npm run lint` passes
- Verified in the browser: orange renders correctly in light and dark mode, theme toggle no longer flashes, and the `--accent` var resolves through the new `var()` indirection (light `#e57e4a`, dark `#e8924f`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)